### PR TITLE
Fix param_cfg

### DIFF
--- a/param_example.cfg
+++ b/param_example.cfg
@@ -38,7 +38,7 @@ field_par:
   #Density field type
   # 0-lognormal
   # 1-1LPT
-  # 2-1LPT
+  # 2-2LPT
   dens_type= 1
   #If dens_type==1 or 2, buffer size (fraction per particle)
   lpt_buffer_fraction= 0.6
@@ -83,7 +83,7 @@ srcs1:
   # 1-> z, 2-> b(z)
   bias_filename= "examples/simple/Bz_test.txt"
   #Do you want to include shear ellipticities?
-  include_shear= true
+  include_lensing= true
   #Do you want to store line-of-sight skewers for each object?
   store_skewers= true
   #You can also store the Gaussian density field (instead of the non-Gaussian one)
@@ -95,7 +95,7 @@ srcs2:
 {
   nz_filename= "examples/simple/Nz2_test.txt"
   bias_filename= "examples/simple/Bz2_test.txt"
-  include_shear= false
+  include_lensing= false
   store_skewers= true
 }
 


### PR DESCRIPTION
I think include_shear changed name into include_lensing (as in the notebook example_CoLoRe.ipynb).

If this is fine, please merge this into master.

Thanks!