### PR TITLE
Added source threshold

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -102,6 +102,7 @@
 #define BG_IH 1005
 #define BG_NZ_SRCS 1006
 #define BG_BZ_SRCS 1007
+#define BG_TZ_SRCS 1015
 #define BG_NORM_SRCS 1008
 #define BG_TZ_IMAP 1009
 #define BG_BZ_IMAP 1010
@@ -312,9 +313,11 @@ typedef struct {
   int do_srcs_lensing; //Do we need to compute the lensing potential?
   int n_srcs; //Number of source types
   char fnameBzSrcs[NPOP_MAX][256]; //Files containing b(z) for each source type
+  char fnameTzSrcs[NPOP_MAX][256]; //Files containing threshold(z) for each source type
   char fnameNzSrcs[NPOP_MAX][256]; //Files containing dN/dzdOmega (in deg^-2)
   double *srcs_nz_arr[NPOP_MAX];
   double *srcs_bz_arr[NPOP_MAX];
+  double *srcs_tz_arr[NPOP_MAX];
   double *srcs_norm_arr[NPOP_MAX];
   double norm_srcs_0[NPOP_MAX]; //Bottom edge of spline for density normalization
   double norm_srcs_f[NPOP_MAX]; //Top edge of spline for density normalization
@@ -411,9 +414,9 @@ void catalog_cartesian_free(CatalogCartesian *cat);
 Catalog *catalog_alloc(int nsrcs,int has_lensing,int has_skw,int skw_gauss,double rmax,int ng);
 void catalog_free(Catalog *cat);
 
-static inline double bias_model(double d,double b)
+static inline double bias_model(double d,double b, double t)
 {
-  if(d<=-1)
+  if(d<=-1 || d < t)
     return 0;
 #ifdef _BIAS_MODEL_2
   if(d < 0)

--- a/src/cstm.c
+++ b/src/cstm.c
@@ -131,7 +131,7 @@ static void cstm_get_beam_properties_single(ParamCoLoRe *par,int ipop)
 	  xn[ax]=(rm*u[ax]+par->pos_obs[ax])*idx;
 	added=interpolate_from_grid(par,xn,&d,NULL,NULL,NULL,NULL,RETURN_DENS,INTERP_CIC);
 	if(added)
-	  cval+=kz[irr]*(bias_model(d,bz[irr])*normz[irr]-1);
+	  cval+=kz[irr]*(bias_model(d,bz[irr], -1)*normz[irr]-1);
       }
       cmap->data[ip]+=cval*dr;
     } //end omp for

--- a/src/density.c
+++ b/src/density.c
@@ -1171,11 +1171,11 @@ static void collect_density_normalization_from_grid(ParamCoLoRe *par,int nz,doub
 	    narr_thr[ind_z]++;
 	    zarr_thr[ind_z]+=redshift;
 	    for(ipop=0;ipop<par->n_srcs;ipop++)
-	      norm_srcs_arr_thr[ipop][ind_z]+=bias_model(d,get_bg(par,r,BG_BZ_SRCS,ipop));
+	      norm_srcs_arr_thr[ipop][ind_z]+=bias_model(d,get_bg(par,r,BG_BZ_SRCS,ipop), get_bg(par, r, BG_TZ_SRCS, ipop));
 	    for(ipop=0;ipop<par->n_imap;ipop++)
-	      norm_imap_arr_thr[ipop][ind_z]+=bias_model(d,get_bg(par,r,BG_BZ_IMAP,ipop));
+	      norm_imap_arr_thr[ipop][ind_z]+=bias_model(d,get_bg(par,r,BG_BZ_IMAP,ipop), -1);
 	    for(ipop=0;ipop<par->n_cstm;ipop++)
-	      norm_cstm_arr_thr[ipop][ind_z]+=bias_model(d,get_bg(par,r,BG_BZ_CSTM,ipop));
+	      norm_cstm_arr_thr[ipop][ind_z]+=bias_model(d,get_bg(par,r,BG_BZ_CSTM,ipop), -1);
 	  }
 	}
       }

--- a/src/imap.c
+++ b/src/imap.c
@@ -198,7 +198,7 @@ static void imap_set_cartesian_single(ParamCoLoRe *par,int ipop)
 	      double dnorm=get_bg(par,r0,BG_NORM_IMAP,ipop);
 	      double rvel=factor_vel*get_rvel(par,ix,iy,iz,x0,y0,z0,r0);
 	      double dr_rsd=rvel*get_bg(par,r0,BG_V1,0)*get_bg(par,r0,BG_IH,0);
-	      double temp=tmean*bias_model(par->grid_dens[index],bias)*dnorm;
+	      double temp=tmean*bias_model(par->grid_dens[index],bias, -1)*dnorm;
 	      irad=get_r_index_imap(imap,r0,irad);
 	      if(irad<0)
 		nsub_here=nsub_lo;

--- a/src/io.c
+++ b/src/io.c
@@ -119,8 +119,10 @@ static ParamCoLoRe *param_colore_new(void)
     par->cstm_kz_arr[ii]=NULL;
     par->cstm_norm_arr[ii]=NULL;
     sprintf(par->fnameBzSrcs[ii],"default");
+    sprintf(par->fnameTzSrcs[ii],"default");
     sprintf(par->fnameNzSrcs[ii],"default");
     par->srcs_bz_arr[ii]=NULL;
+    par->srcs_tz_arr[ii]=NULL;
     par->srcs_nz_arr[ii]=NULL;
     par->srcs_norm_arr[ii]=NULL;
     par->lensing_srcs[ii]=0;
@@ -328,6 +330,7 @@ ParamCoLoRe *read_run_params(char *fname,int test_memory)
     sprintf(c_dum,"srcs%d",ii+1);
     conf_read_string(conf,c_dum,"nz_filename",par->fnameNzSrcs[ii]);
     conf_read_string(conf,c_dum,"bias_filename",par->fnameBzSrcs[ii]);
+    conf_read_string(conf,c_dum,"threshold_filename",par->fnameTzSrcs[ii]);
     conf_read_bool(conf,c_dum,"include_lensing",&(par->lensing_srcs[ii]));
     if(par->lensing_srcs[ii])
       par->do_srcs_lensing=1;
@@ -1256,6 +1259,7 @@ void param_colore_free(ParamCoLoRe *par)
   if(par->do_srcs) {
     for(ii=0;ii<par->n_srcs;ii++) {
       free(par->srcs_bz_arr[ii]);
+      free(par->srcs_tz_arr[ii]);
       free(par->srcs_nz_arr[ii]);
       free(par->srcs_norm_arr[ii]);
       if(par->cats_c!=NULL) {

--- a/src/io.c
+++ b/src/io.c
@@ -171,6 +171,19 @@ static void conf_read_string(config_t *conf,char *secname,char *varname,char *ou
   sprintf(out,"%s",str);
 }
 
+static int conf_read_string_optional(config_t *conf, char *secname, char *varname, char **out)
+  {
+    int stat;
+    char fullpath[256];
+    const char *str;
+    sprintf(fullpath,"%s.%s",secname,varname);
+    stat=config_lookup_string(conf,fullpath,&str);
+    if(stat==CONFIG_FALSE)
+      *out = NULL;
+    else
+      sprintf(out,"%s",str);
+  }
+
 static void conf_read_double(config_t *conf,char *secname,char *varname,double *out)
 {
   int stat;
@@ -330,7 +343,7 @@ ParamCoLoRe *read_run_params(char *fname,int test_memory)
     sprintf(c_dum,"srcs%d",ii+1);
     conf_read_string(conf,c_dum,"nz_filename",par->fnameNzSrcs[ii]);
     conf_read_string(conf,c_dum,"bias_filename",par->fnameBzSrcs[ii]);
-    conf_read_string(conf,c_dum,"threshold_filename",par->fnameTzSrcs[ii]);
+    conf_read_string_optional(conf,c_dum,"threshold_filename",par->fnameTzSrcs[ii]);
     conf_read_bool(conf,c_dum,"include_lensing",&(par->lensing_srcs[ii]));
     if(par->lensing_srcs[ii])
       par->do_srcs_lensing=1;

--- a/src/srcs.c
+++ b/src/srcs.c
@@ -171,7 +171,7 @@ static void srcs_set_cartesian_single(ParamCoLoRe *par,int ipop)
 	    if(ndens>0) {
 	      double bias=get_bg(par,r,BG_BZ_SRCS,ipop);
 	      double dnorm=get_bg(par,r,BG_NORM_SRCS,ipop);
-	      double lambda=ndens*cell_vol*bias_model(par->grid_dens[index],bias)*dnorm;
+	      double lambda=ndens*cell_vol*bias_model(par->grid_dens[index],bias, get_bg(par, r, BG_TZ_SRCS, ipop))*dnorm;
 	      //double lambda=ndens*cell_vol*dnorm;
 	      npp=rng_poisson(lambda,rng_thr);
 	    }


### PR DESCRIPTION
This pull request adds the threshold for lightcone sources.

This was the version used for the validation of the DESI Lyman-α Y1 BAO measurements.

Maybe @damonge do you want me to make some changes to the code before merging? For example, the input threshold file is now required, but maybe we should make it optional.

Also @andreufont suggested adding the input files used for the analysis into the repo. (input thresholds and biases)