### PR TITLE
Arbitrary source planes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ USE_MPI = yes
 #GSL
 #GSL_INC = -I/add/path
 #GSL_LIB = -L/add/path
-GSL_INC = -I/home/alonso/include
-GSL_LIB = -L/home/alonso/lib
+GSL_INC = -I/home/damonge/include
+GSL_LIB = -L/home/damonge/lib
 #FFTW
 FFTW_INC =
 FFTW_LIB =

--- a/param_example.cfg
+++ b/param_example.cfg
@@ -122,7 +122,7 @@ imap1:
 kappa:
 {
   #Redshifts at which maps should be generated
-  z_out= [0.4]
+  z_out= [1100.]
   nside= 64
 }
 
@@ -130,7 +130,7 @@ kappa:
 #of the ISW effect (time derivative of the gravitational potential).
 isw:
 {
-  z_out= [0.4]
+  z_out= [1100.]
   nside= 64
 }
 

--- a/src/cosmo.c
+++ b/src/cosmo.c
@@ -803,7 +803,8 @@ void cosmo_set(ParamCoLoRe *par)
 	  fprintf(par->f_dbg,"\n");
 #endif //_DEBUG
 #else //_ADD_EXTRA_KAPPA
-	report_error(1,"Source plane %d outside redshift range\n",ii+1);
+	print_info("Lensing source plane %d outside redshift range. Will only fill up to z=%.3lf\n",
+		   ii+1,par->z_max);
 #endif //_ADD_EXTRA_KAPPA
       }
     }
@@ -843,7 +844,8 @@ void cosmo_set(ParamCoLoRe *par)
 	  fprintf(par->f_dbg,"\n");
 #endif //_DEBUG
 #else //_ADD_EXTRA_KAPPA
-	report_error(1,"Source plane %d outside redshift range\n",ii+1);
+	print_info("ISW source plane %d outside redshift range. Will only fill up to z=%.3lf\n",
+		   ii+1,par->z_max);
 #endif //_ADD_EXTRA_KAPPA
       }
     }

--- a/src/kappa.c
+++ b/src/kappa.c
@@ -98,7 +98,7 @@ void kappa_get_beam_properties(ParamCoLoRe *par)
     double *inv_r_max=my_malloc(kmap->nr*sizeof(double));
     for(i_r=0;i_r<kmap->nr;i_r++) {
       int i_r_here=(int)(kmap->rf[i_r]*idr+0.5);
-      inv_r_max[i_r]=1./(i_r_here*dr);
+      inv_r_max[i_r]=1./kmap->rf[i_r];
       i_r_max_arr[i_r]=MIN(i_r_here,nr-1);
     }
     i_r_min_arr[0]=0;


### PR DESCRIPTION
Allows for lensing (and ISW) source planes to lie outside of the box. Line-of-sight integrals will only contain information up to z=z_max (passed in the param file), but the radial kernel will be that of a source plane at the requested distance.

Closes #75 